### PR TITLE
docs: 修复中英文README的Star History图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ https://api.bugpk.com/api/douyin.php?url=https://v.douyin.com/xxxx/
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=jiuhunwl/short_videos&type=date&legend=top-left)](https://www.star-history.com/?repos=jiuhunwl%2Fshort_videos&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jiuhunwl/short_videos&type=date&legend=top-left)](https://star-history.dera.page/#jiuhunwl/short_videos&type=date&legend=top-left)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -515,7 +515,7 @@ Thank you to the following generous supporters for your sponsorship! Your suppor
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=jiuhunwl/short_videos&type=date&legend=top-left)](https://www.star-history.com/?repos=jiuhunwl%2Fshort_videos&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jiuhunwl/short_videos&type=date&legend=top-left)](https://star-history.dera.page/#jiuhunwl/short_videos&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
当前Star History图表因GitHub stargazer接口限制已无法正常显示，需要尽快修复。已将中英文README中的Star History图表链接迁移到新地址，使Star增长趋势可以正常展示。